### PR TITLE
Application description is mandatory for rebar3

### DIFF
--- a/src/eid.app.src
+++ b/src/eid.app.src
@@ -13,6 +13,7 @@
 %% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 {application, eid, [
+    {description, "Unique ID generator"},
     {id, "eid"},
     {vsn, "0.5.0"},
     {modules, []},


### PR DESCRIPTION
Hello! Great module, but:
rebar3 release fails if a description is missing